### PR TITLE
Fix: Adjust JS paths for GitHub Pages compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>MuSoci</title>
   <link rel="preload" href="styles.css" as="style">
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@600&family=Open+Sans:wght@300;400&display=swap" as="style" crossorigin="anonymous">
-  <link rel="preload" href="/router.js" as="script" crossorigin="anonymous">
-  <link rel="preload" href="/app.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="router.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="app.js" as="script" crossorigin="anonymous">
   <link href="styles.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Poppins:wght@600&family=Open+Sans:wght@300;400&display=swap" rel="stylesheet"/>
   <!-- Google Tag Manager -->
@@ -24,8 +24,8 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <musoci-app></musoci-app>
-  <script type="module" src="/router.js"></script>
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="router.js"></script>
+  <script type="module" src="app.js"></script>
   <script src="script.js">
   </script>
  </body>


### PR DESCRIPTION
I changed absolute paths for router.js and app.js in index.html to relative paths. This includes both the preload links in the <head> and the module script tags at the end of the <body>.

This change ensures that these core JavaScript files are loaded correctly when the site is deployed to GitHub Pages as a project site (e.g., https://username.github.io/repository-name/), where assets need to be referenced relative to the repository root rather than the domain root. This resolves 404 errors previously encountered for these files on GitHub Pages.